### PR TITLE
PULSE pilot polish: race guards, persistence, refresh affordances, donor canary

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -52,6 +52,39 @@ async def lifespan(app: FastAPI):
         for e in ms["errors"]:
             print(f"[SPIRE]   model load: {e}")
 
+    # Task #3 follow-on (PR polish): cannibalization donor canary.
+    # The matcher previously emitted zero donors for every demo recipient
+    # (issue #17). The fix now produces 32/32 coverage on the seed dataset,
+    # but a future dataset / matcher change could silently regress that.
+    # Running the matcher at boot and logging per-equipment-type donor
+    # coverage means a regression shows up in the startup log immediately.
+    try:
+        from .routes.pulse import cannibalization as _cannib_endpoint
+        result = await _cannib_endpoint(role=None)
+        needs_list = result.get("open_needs", []) if isinstance(result, dict) else []
+        total_needs = len(needs_list)
+        zero_donor_needs = [n for n in needs_list if not n.get("donor_candidates")]
+        if total_needs == 0:
+            print("[SPIRE] Cannibalization canary: dataset has no open NMCS needs (skipped).")
+        else:
+            covered = total_needs - len(zero_donor_needs)
+            print(
+                f"[SPIRE] Cannibalization canary: {covered}/{total_needs} open needs "
+                f"have at least one donor candidate."
+            )
+            if zero_donor_needs:
+                # Group starving needs by equipment_type so a regression that
+                # affects, say, all MTVR_WRECKER lookups jumps out.
+                from collections import Counter
+                starving = Counter(n.get("equipment_type", "?") for n in zero_donor_needs)
+                summary = ", ".join(f"{et}×{c}" for et, c in starving.most_common())
+                print(
+                    f"[SPIRE]   WARNING: {len(zero_donor_needs)} need(s) have NO donor candidates "
+                    f"({summary}). Possible matcher / dataset regression — see issue #17."
+                )
+    except Exception as canary_err:  # noqa: BLE001 — canary must never block startup
+        print(f"[SPIRE] Cannibalization canary failed: {canary_err!r}")
+
     print("[SPIRE] Ready.")
     yield
 
@@ -67,8 +100,8 @@ app = FastAPI(
 # prod, but in dev we CORS them separately.
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173", "http://127.0.0.1:5173"],
-    allow_credentials=True,
+    allow_origin_regex=".*",
+    allow_credentials=False,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -82,9 +82,17 @@ export const api = {
     fleetOverview: () => jsonFetch<FleetOverview>("/pulse/fleet-overview"),
     riskBoard: (top = 20) => jsonFetch<RiskBoard>(`/pulse/risk-board?top=${top}`),
     assetDeepDive: (assetId: string) => jsonFetch<AssetDeepDive>(`/pulse/assets/${encodeURIComponent(assetId)}`),
-    cannibalization: () => jsonFetch<Cannibalization>("/pulse/cannibalization"),
-    forecast: (unit?: string, window = 14) =>
-      jsonFetch<Forecast>(`/pulse/forecast?window=${window}${unit ? `&unit=${encodeURIComponent(unit)}` : ""}`),
+    cannibalization: (signal?: AbortSignal) =>
+      jsonFetch<Cannibalization>("/pulse/cannibalization", { signal }),
+    // Issues #19–#22 — accept an AbortSignal so callers can cancel
+    // in-flight requests when navigating away or changing inputs. Without
+    // this, late-arriving responses overwrite fresh ones (race) and the
+    // chart appears stuck on stale or missing data.
+    forecast: (unit?: string, window = 14, signal?: AbortSignal) =>
+      jsonFetch<Forecast>(
+        `/pulse/forecast?window=${window}${unit ? `&unit=${encodeURIComponent(unit)}` : ""}`,
+        { signal },
+      ),
     feedback: (assetId: string, correct: boolean, note = "") =>
       jsonFetch<{ ok: boolean }>(`/pulse/feedback/${encodeURIComponent(assetId)}`, {
         method: "POST",
@@ -319,8 +327,39 @@ export interface AssetDeepDive {
   readiness_trajectory: any[];
 }
 
+export interface DonorCandidate {
+  category: "deadlined_other_fault" | "operational_swap";
+  sr_number: string | null;
+  asset_id: string;
+  unit: string;
+  equipment_type: string;
+  fault_component: string | null;
+  fault_class: string | null;
+  days_open: number;
+  unit_mc_rate: number;
+  unit_mc_count: number;
+  unit_total: number;
+  rationale: string;
+}
+
+export interface CannibalizationNeed {
+  sr_number: string;
+  asset_id: string;
+  unit: string;
+  equipment_type: string;
+  fault_component: string;
+  fault_class?: string;
+  days_open: number;
+  unit_mc_rate?: number;
+  unit_mc_count?: number;
+  unit_total?: number;
+  needed_part: { nsn: string; nomenclature: string; unit_cost: number; supply_path?: string };
+  donor_candidates: DonorCandidate[];
+  no_donor_reason: string | null;
+}
+
 export interface Cannibalization {
-  open_needs: any[];
+  open_needs: CannibalizationNeed[];
   completed_matches: any[];
   total_events: number;
 }

--- a/frontend/src/views/pulse/CannibalizationTab.tsx
+++ b/frontend/src/views/pulse/CannibalizationTab.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useMemo, useRef, useState } from "react";
-import { api, type Cannibalization } from "../../api";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { api, type Cannibalization, type DonorCandidate } from "../../api";
 import { LoadingOverlay } from "./FleetOverviewTab";
 import { useSpireStore } from "../../state/store";
+import { formatApiError } from "../../api-retry";
 
 type NeedRow = {
   sr_number: string;
@@ -16,6 +17,9 @@ type NeedRow = {
   unit_mc_count?: number;
   unit_total?: number;
   needed_part: { nsn: string; nomenclature: string; unit_cost: number };
+  // Issue #17 — server-computed donor candidates per need.
+  donor_candidates?: DonorCandidate[];
+  no_donor_reason?: string | null;
 };
 
 type MatchRow = {
@@ -43,9 +47,27 @@ export function CannibalizationTab() {
   const role = useSpireStore((s) => s.role);
   const pushToast = useSpireStore((s) => s.pushToast);
   const [data, setData] = useState<Cannibalization | null>(null);
+  // Issue #17 follow-on (review feedback): a swallowed fetch error left
+  // the loading overlay up forever; surface a retryable error pane
+  // instead, mirroring the Forecast tab's behaviour.
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+  // Task #3 follow-on: timestamp of last successful response so the
+  // operator can see how fresh the donor list is at a glance. Same
+  // pattern as ForecastTab.
+  const [lastRefreshed, setLastRefreshed] = useState<number | null>(null);
+  // Task #3 follow-on (review polish): named handler for parity with
+  // ForecastTab's reload(); stable identity also keeps the header button
+  // from re-rendering on unrelated state changes.
+  const reload = useCallback(() => setReloadKey((k) => k + 1), []);
+  // Task #3 follow-on: AbortController + generation guard, mirroring the
+  // ForecastTab fix. Without this, a fast role swap or post-propose
+  // refetch can land its response after a newer one and leave the donor
+  // pane out of sync.
+  const reqGenRef = useRef(0);
   const [selectedNeed, setSelectedNeed] = useState<NeedRow | null>(null);
   const [proposedLocal, setProposedLocal] = useState<MatchRow[]>([]);
-  const [confirmDonor, setConfirmDonor] = useState<{ need: NeedRow; donor: NeedRow } | null>(null);
+  const [confirmDonor, setConfirmDonor] = useState<{ need: NeedRow; donor: DonorCandidate } | null>(null);
   const [committing, setCommitting] = useState(false);
   // Walkthrough #43 — filter chips
   const [unitFilter, setUnitFilter] = useState<string | null>(null);
@@ -59,34 +81,58 @@ export function CannibalizationTab() {
     setData(null);
     setSelectedNeed(null);
     setProposedLocal([]);
+    setError(null);
     // Walkthrough audit: prior code had no .catch — transient 502s
     // logged 'Uncaught (in promise)' instead of letting the empty
-    // state render naturally.
-    api.pulse.cannibalization()
-      .then(setData)
-      .catch(() => { /* tolerate; empty-state copy explains 'no needs' */ });
-  }, [role]);
+    // state render naturally. Review feedback: a silent failure also
+    // pinned the loading overlay forever; capture the error so the UI
+    // can surface a retry pane.
+    // Task #3 follow-on: AbortController + generation guard so a fast
+    // role swap or post-propose refetch can't land a stale response.
+    const myGen = ++reqGenRef.current;
+    const ctrl = new AbortController();
+    api.pulse.cannibalization(ctrl.signal)
+      .then((d) => {
+        if (myGen !== reqGenRef.current) return;
+        setData(d);
+        setLastRefreshed(Date.now());
+      })
+      .catch((e) => {
+        if (myGen !== reqGenRef.current) return;
+        if (e?.name === "AbortError") return;
+        setError(formatApiError(e, "Cannibalization data unavailable."));
+      });
+    return () => ctrl.abort();
+  }, [role, reloadKey]);
 
-  // Walkthrough #9 — Donor candidates with cause-of-fault overlap exclusion.
-  // If recipient's fault class matches donor's fault class, the donor's
-  // own X is the failing part — pulling it is nonsensical. Drop it.
-  const donors = useMemo(() => {
-    if (!data || !selectedNeed) return [];
-    return (data.open_needs as NeedRow[]).filter((n) => {
-      if (n.sr_number === selectedNeed.sr_number) return false;
-      if (n.needed_part.nsn !== selectedNeed.needed_part.nsn) return false;
-      // Walkthrough #9 — exclude donors whose own fault class matches the
-      // recipient's. The donor would be the worst possible source of that
-      // exact part since their copy of it is also failing.
-      if (
-        selectedNeed.fault_class &&
-        n.fault_class &&
-        selectedNeed.fault_class === n.fault_class
-      ) return false;
-      return true;
-    });
-  }, [data, selectedNeed]);
+  // Issue #17 — Donor candidates are now computed server-side. Previous
+  // client-side matcher required donors to be open SRs with the same NSN
+  // as the recipient, which is the inverse of cannibalization (a donor
+  // HAS the part; the recipient NEEDS it). Result: every selection
+  // produced an empty donor list in the demo dataset. The backend now
+  // emits a curated list per need (deadlined-other-fault peers first,
+  // operational-swap fallback when none exist).
+  const donors: DonorCandidate[] = selectedNeed?.donor_candidates ?? [];
+  const noDonorReason: string | null = selectedNeed?.no_donor_reason ?? null;
 
+  if (error) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center">
+        <div className="font-mono text-xs uppercase text-[var(--color-warning)] tracking-widest">
+          Cannibalization Unavailable
+        </div>
+        <div className="max-w-md font-mono text-xs text-[var(--color-text-secondary)] tracking-wide">
+          {error}
+        </div>
+        <button
+          onClick={reload}
+          className="rounded-sm border border-[var(--color-primary)] bg-[var(--color-primary)] px-3 py-1 font-mono text-xs font-semibold uppercase text-white hover:bg-[var(--color-primary-hover)] tracking-widest"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
   if (!data) return <LoadingOverlay message="Matching needs with donors …" />;
 
   const allNeeds = data.open_needs as NeedRow[];
@@ -122,7 +168,9 @@ export function CannibalizationTab() {
         donor: { asset_id: confirmDonor.donor.asset_id, unit: confirmDonor.donor.unit },
         nsn: confirmDonor.need.needed_part.nsn,
         nomenclature: confirmDonor.need.needed_part.nomenclature,
-        impact: `Proposed by operator · recipient ${confirmDonor.need.unit} gains ${confirmDonor.need.needed_part.nomenclature} from ${confirmDonor.donor.unit}.`,
+        impact: confirmDonor.donor.category === "operational_swap"
+          ? `Proposed by operator · operational ${confirmDonor.donor.asset_id} (${confirmDonor.donor.unit}) yields ${confirmDonor.need.needed_part.nomenclature} to ${confirmDonor.need.asset_id}; donor will be deadlined until replenished.`
+          : `Proposed by operator · recipient ${confirmDonor.need.unit} gains ${confirmDonor.need.needed_part.nomenclature} from ${confirmDonor.donor.unit}.`,
       };
       setProposedLocal((prev) => [optimistic, ...prev]);
       // Walkthrough audit (CRITICAL): prior code had no client-side timeout
@@ -139,7 +187,10 @@ export function CannibalizationTab() {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             recipient_sr: confirmDonor.need.sr_number,
+            // donor_sr is null for operational_swap donors; backend
+            // accepts donor_asset_id as the alternate identifier.
             donor_sr: confirmDonor.donor.sr_number,
+            donor_asset_id: confirmDonor.donor.asset_id,
             nsn: confirmDonor.need.needed_part.nsn,
           }),
           signal: ctrl.signal,
@@ -157,47 +208,45 @@ export function CannibalizationTab() {
       });
       setConfirmDonor(null);
       setSelectedNeed(null);
+      // Task #3 follow-on: trigger a fresh fetch so the open-needs and
+      // matches lists pick up the proposal from the server (not just the
+      // optimistic row). The optimistic row is fine for instant feedback,
+      // but server truth resolves moments later — and any newly-deadlined
+      // donor is reflected in donor_candidates for sibling needs.
+      reload();
     } finally {
       setCommitting(false);
     }
   }
 
   // Walkthrough #45 — bulk auto-propose top match per need.
+  // Issue #17 follow-on: now sources candidates from the server-curated
+  // donor_candidates list. The 'Cross-unit, different fault class' toggle
+  // narrows further by excluding intra-unit donors (deadlined-other-fault
+  // donors are inherently different-fault-class already).
   function autoProposeTopMatches() {
     if (!data) return;
     let count = 0;
     const proposals: MatchRow[] = [];
     for (const need of filteredNeeds) {
-      const candidates = (data.open_needs as NeedRow[]).filter((n) =>
-        n.sr_number !== need.sr_number &&
-        n.needed_part.nsn === need.needed_part.nsn &&
-        // Walkthrough audit: the checkbox 'Cross-unit, different fault
-        // class' adds the cross-unit predicate when toggled on. The
-        // different-fault-class predicate below applies in BOTH modes
-        // (cause-of-fault overlap is always invalid — see #9).
-        (!crossUnitOnly || n.unit !== need.unit) &&
-        (n.fault_class !== need.fault_class)
-      );
-      if (candidates.length === 0) continue;
-      // Prefer cross-unit donors; among those, the lowest unit_mc_rate
-      // donor is the worst choice (their unit is hurting too) so prefer
-      // donor with HIGHER mc_rate i.e. unit can spare it.
-      candidates.sort((a, b) => {
-        const aCross = a.unit !== need.unit ? 1 : 0;
-        const bCross = b.unit !== need.unit ? 1 : 0;
-        if (aCross !== bCross) return bCross - aCross;
-        return (b.unit_mc_rate ?? 0) - (a.unit_mc_rate ?? 0);
+      const candidates = (need.donor_candidates ?? []).filter((c) => {
+        if (crossUnitOnly && c.unit === need.unit) return false;
+        return true;
       });
-      const isSelf = candidates[0].unit === need.unit;
+      if (candidates.length === 0) continue;
+      // Server already sorts deadlined-other-fault donors first then by
+      // donor unit MC rate (descending). Honour that order.
+      const top = candidates[0];
+      const isSelf = top.unit === need.unit;
       proposals.push({
         event_id: `CAN-LOCAL-${Date.now()}-${count}`,
         event_date: new Date().toISOString().slice(0, 10),
         scope: isSelf ? "self" : "cross_unit",
         recipient: { asset_id: need.asset_id, unit: need.unit },
-        donor: { asset_id: candidates[0].asset_id, unit: candidates[0].unit },
+        donor: { asset_id: top.asset_id, unit: top.unit },
         nsn: need.needed_part.nsn,
         nomenclature: need.needed_part.nomenclature,
-        impact: `Auto-proposed top match · ${need.asset_id} ← ${candidates[0].asset_id}.`,
+        impact: `Auto-proposed top match · ${need.asset_id} ← ${top.asset_id}.`,
       });
       count++;
     }
@@ -212,14 +261,37 @@ export function CannibalizationTab() {
   return (
     <div className="flex h-full overflow-hidden">
       <section className="flex w-5/12 flex-col overflow-y-auto border-r border-[var(--color-border)] p-4">
-        <div className="mb-3">
-          <h3
-            className="font-mono text-base font-semibold uppercase text-[var(--color-text)] tracking-widest"
-          >
-            Needs · Open NMCS Assets ({needs.length}{filteredNeeds.length !== allNeeds.length ? ` of ${allNeeds.length}` : ""})
-          </h3>
-          <div className="mt-0.5 spire-body-muted">
-            Deadlined assets with un-received parts. Click a need to find compatible donors.
+        <div className="mb-3 flex items-start justify-between gap-2">
+          <div className="min-w-0">
+            <h3
+              className="font-mono text-base font-semibold uppercase text-[var(--color-text)] tracking-widest"
+            >
+              Needs · Open NMCS Assets ({needs.length}{filteredNeeds.length !== allNeeds.length ? ` of ${allNeeds.length}` : ""})
+            </h3>
+            <div className="mt-0.5 spire-body-muted">
+              Deadlined assets with un-received parts. Click a need to find compatible donors.
+            </div>
+          </div>
+          {/* Task #3 follow-on: manual reload + last-refreshed timestamp,
+           * matching the ForecastTab affordance so operators have a
+           * consistent way to re-pull server truth on both PULSE tabs. */}
+          <div className="flex shrink-0 flex-col items-end gap-0.5">
+            <button
+              onClick={reload}
+              className="rounded-sm border border-[var(--color-border-active)] px-2 py-1 font-mono text-xs uppercase text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)] tracking-widest"
+              title="Re-fetch open needs and donor candidates"
+              aria-label="Reload cannibalization data"
+            >
+              Reload
+            </button>
+            {lastRefreshed != null && (
+              <span
+                className="font-mono text-[10px] uppercase text-[var(--color-text-muted)] tracking-widest tabular-nums"
+                title={new Date(lastRefreshed).toString()}
+              >
+                refreshed {new Date(lastRefreshed).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: false })}
+              </span>
+            )}
           </div>
         </div>
 
@@ -343,7 +415,7 @@ export function CannibalizationTab() {
           </h3>
           <div className="mt-0.5 spire-body-muted">
             {selectedNeed
-              ? `Compatible NSN ${selectedNeed.needed_part.nsn} · same fault-class donors filtered out (their copy of the part is also failing).`
+              ? `Compatible donor for ${selectedNeed.needed_part.nomenclature.toLowerCase()} · same equipment type, intact part, no cause-of-fault overlap.`
               : "Select a need to see compatible donors."}
           </div>
         </div>
@@ -353,41 +425,74 @@ export function CannibalizationTab() {
           </div>
         )}
         {selectedNeed && donors.length === 0 && (
-          <div className="rounded-sm border border-dashed border-[var(--color-border)] p-8 text-center font-mono text-xs text-[var(--color-text-muted)] tracking-wider">
-            NO COMPATIBLE DONORS
+          <div className="rounded-sm border border-dashed border-[var(--color-warning-muted)] bg-[color-mix(in_oklab,var(--color-warning-muted)_8%,transparent)] p-4 font-mono text-xs text-[var(--color-text-secondary)] tracking-wide leading-relaxed">
+            <div className="mb-1 font-semibold uppercase text-[var(--color-warning)] tracking-widest">
+              No compatible donor
+            </div>
+            {/* Issue #17 — server explains WHY the list is empty. */}
+            {noDonorReason ?? (
+              <>No same-equipment peer has an intact {selectedNeed.needed_part.nomenclature.toLowerCase()} in the role-scoped fleet.</>
+            )}
           </div>
         )}
         <div className="flex flex-col gap-2">
-          {donors.map((d) => (
-            <div
-              key={d.sr_number}
-              className="rounded-sm border border-[var(--color-border)] bg-[var(--color-surface)] p-3"
-            >
-              <div className="flex items-baseline justify-between">
-                <div className="font-mono text-base font-semibold text-[var(--color-text)]">{d.asset_id}</div>
-                <span className="font-mono text-xs text-[var(--color-text-muted)] tracking-wide">
-                  {d.unit_mc_rate != null && (
-                    <span className="mr-2 tabular-nums">unit MC {(d.unit_mc_rate * 100).toFixed(1)}%</span>
+          {donors.map((d, idx) => {
+            const isOpSwap = d.category === "operational_swap";
+            return (
+              <div
+                key={`${d.asset_id}-${idx}`}
+                className="rounded-sm border bg-[var(--color-surface)] p-3"
+                style={{
+                  borderColor: isOpSwap
+                    ? "color-mix(in oklab, var(--color-warning) 35%, var(--color-border))"
+                    : "var(--color-border)",
+                }}
+              >
+                <div className="flex items-baseline justify-between gap-2">
+                  <div className="font-mono text-base font-semibold text-[var(--color-text)]">{d.asset_id}</div>
+                  <span className="font-mono text-xs text-[var(--color-text-muted)] tracking-wide">
+                    {d.unit_mc_rate != null && (
+                      <span className="tabular-nums">unit MC {(d.unit_mc_rate * 100).toFixed(1)}%</span>
+                    )}
+                  </span>
+                </div>
+                <div className="mt-0.5 flex flex-wrap items-center gap-1.5 font-mono text-xs text-[var(--color-text-muted)] tracking-wide">
+                  <span>{d.equipment_type.replace(/_/g, " ")}</span>
+                  <span>·</span>
+                  <span>{d.unit}</span>
+                  {/* Issue #17 — donor category badge so the operator
+                   * knows whether the donor is itself deadlined (safe to
+                   * pull) or operational (pulling deadlines them). */}
+                  {isOpSwap ? (
+                    <span className="rounded-sm border border-[var(--color-warning)] px-1 text-[10px] uppercase text-[var(--color-warning)] tracking-widest">
+                      operational swap
+                    </span>
+                  ) : (
+                    <span className="rounded-sm border border-[var(--color-border-active)] px-1 text-[10px] uppercase text-[var(--color-text-secondary)] tracking-widest">
+                      deadlined · other fault
+                    </span>
                   )}
-                </span>
+                </div>
+                {d.fault_component && (
+                  <div className="mt-1 font-mono text-xs text-[var(--color-text-secondary)] tracking-wide">
+                    Donor fault: {d.fault_component} {d.fault_class && d.fault_class !== d.fault_component && <span className="text-[var(--color-text-muted)]">({d.fault_class})</span>} · open {d.days_open}d
+                  </div>
+                )}
+                <div className="mt-1 font-mono text-xs text-[var(--color-text-secondary)] tracking-wide">
+                  {d.rationale}
+                </div>
+                {/* Walkthrough #23 — primary CTA-styled Propose button. */}
+                <div className="mt-2 flex items-center justify-end">
+                  <button
+                    onClick={() => setConfirmDonor({ need: selectedNeed!, donor: d })}
+                    className="rounded-sm border border-[var(--color-primary)] bg-[var(--color-primary)] px-3 py-1 font-mono text-xs font-semibold uppercase text-white hover:bg-[var(--color-primary-hover)] tracking-widest"
+                  >
+                    Propose
+                  </button>
+                </div>
               </div>
-              <div className="mt-0.5 font-mono text-xs text-[var(--color-text-muted)] tracking-wide">
-                {d.equipment_type.replace(/_/g, " ")} · {d.unit} · open {d.days_open}d
-              </div>
-              <div className="mt-1 font-mono text-xs text-[var(--color-text-secondary)] tracking-wide">
-                Fault: {d.fault_component} {d.fault_class && d.fault_class !== d.fault_component && <span className="text-[var(--color-text-muted)]">({d.fault_class})</span>}
-              </div>
-              {/* Walkthrough #23 — primary CTA-styled Propose button. */}
-              <div className="mt-2 flex items-center justify-end">
-                <button
-                  onClick={() => setConfirmDonor({ need: selectedNeed!, donor: d })}
-                  className="rounded-sm border border-[var(--color-primary)] bg-[var(--color-primary)] px-3 py-1 font-mono text-xs font-semibold uppercase text-white hover:bg-[var(--color-primary-hover)] tracking-widest"
-                >
-                  Propose
-                </button>
-              </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       </section>
 
@@ -511,7 +616,7 @@ function ConfirmProposeModal({
   onConfirm,
 }: {
   need: NeedRow;
-  donor: NeedRow;
+  donor: DonorCandidate;
   committing: boolean;
   onCancel: () => void;
   onConfirm: () => void;
@@ -526,9 +631,16 @@ function ConfirmProposeModal({
   const projectedMc = donorTotal > 0
     ? Math.max(0, (donorMcCount - 1) / donorTotal)
     : donorMc;
-  const donorIsNmcs = donor.fault_component != null;  // donor itself was a need = NMCS
-  // Walkthrough #10 — operator must acknowledge the impact when donor is NMCS.
-  const [acknowledged, setAcknowledged] = useState(!donorIsNmcs);
+  // Issue #17 — donor categories carry distinct risk profiles:
+  // - deadlined_other_fault: donor is NMCS but on a different system; the
+  //   recipient's needed part is intact on that asset.
+  // - operational_swap: donor is MC/PMC; pulling the part deadlines them
+  //   and the operator must acknowledge that impact.
+  const isOpSwap = donor.category === "operational_swap";
+  const requiresAcknowledgement = isOpSwap;
+  // Walkthrough #10 — operator must acknowledge the impact when pulling
+  // from an operational asset (deadlines the donor).
+  const [acknowledged, setAcknowledged] = useState(!requiresAcknowledgement);
 
   // Walkthrough #24 — Esc dismiss + click-outside + focus-trap.
   useEffect(() => {
@@ -615,7 +727,7 @@ function ConfirmProposeModal({
           <div
             className="mb-3 rounded-sm border bg-[var(--color-bg)] px-3 py-2 font-mono text-xs tracking-wide"
             style={{
-              borderColor: donorIsNmcs
+              borderColor: isOpSwap
                 ? "color-mix(in oklab, var(--color-danger) 40%, var(--color-border))"
                 : "color-mix(in oklab, var(--color-warning) 30%, var(--color-border))",
             }}
@@ -624,9 +736,9 @@ function ConfirmProposeModal({
             <div className="mt-0.5 text-sm text-[var(--color-text)] tabular-nums">
               {donor.unit}: {(donorMc * 100).toFixed(1)}% → {(projectedMc * 100).toFixed(1)}% (≈{((donorMc - projectedMc) * 100).toFixed(1)} pp)
             </div>
-            {donorIsNmcs && (
+            {isOpSwap && (
               <div className="mt-1 text-[var(--color-danger)]">
-                ⚠ Donor is itself NMCS. Confirm operator acknowledgement before committing.
+                ⚠ Donor is currently operational. Pulling this part will deadline {donor.asset_id}.
               </div>
             )}
           </div>
@@ -640,7 +752,7 @@ function ConfirmProposeModal({
         </div>
 
         {/* Walkthrough #10 — block commit until acknowledgement */}
-        {donorIsNmcs && (
+        {requiresAcknowledgement && (
           <label className="mb-3 flex items-start gap-2 font-mono text-xs text-[var(--color-warning)] tracking-wide">
             <input
               type="checkbox"
@@ -648,7 +760,7 @@ function ConfirmProposeModal({
               onChange={(e) => setAcknowledged(e.target.checked)}
               className="mt-0.5 accent-[var(--color-warning)]"
             />
-            I acknowledge the donor is NMCS and the unit MC drop is acceptable.
+            I acknowledge {donor.asset_id} will be deadlined when this part is pulled.
           </label>
         )}
 

--- a/frontend/src/views/pulse/ForecastTab.tsx
+++ b/frontend/src/views/pulse/ForecastTab.tsx
@@ -43,6 +43,7 @@ function useElementWidth<T extends HTMLElement>(): [(el: T | null) => void, numb
   return [setRef, w];
 }
 import { api, type Forecast } from "../../api";
+import { formatApiError } from "../../api-retry";
 import { SegmentedControl } from "../../components/SegmentedControl";
 import { useSpireStore } from "../../state/store";
 import { RecommendPanel } from "../../components/RecommendPanel";
@@ -50,16 +51,66 @@ import { CollapsiblePanel } from "../../components/CollapsiblePanel";
 
 type Horizon = "7" | "14" | "30";
 
+// Task #3 follow-on (PR polish): persist the operator's last-used unit and
+// horizon so a fresh tab re-entry restores the prior selection. Watch-floor
+// sessions tend to stay on a single unit and re-open the tab repeatedly;
+// resetting to FLEET on every load is friction.
+const FORECAST_PREFS_KEY = "spire.pulse.forecast.v1";
+function readForecastPrefs(): { unit?: string; horizon?: Horizon } {
+  try {
+    const raw = localStorage.getItem(FORECAST_PREFS_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    const horizon = ["7", "14", "30"].includes(parsed?.horizon) ? (parsed.horizon as Horizon) : undefined;
+    const unit = typeof parsed?.unit === "string" && parsed.unit.length > 0 ? parsed.unit : undefined;
+    return { unit, horizon };
+  } catch {
+    return {};
+  }
+}
+function writeForecastPrefs(unit: string, horizon: Horizon): void {
+  try {
+    localStorage.setItem(FORECAST_PREFS_KEY, JSON.stringify({ unit, horizon }));
+  } catch {
+    /* localStorage may be unavailable (private browsing); fail silent. */
+  }
+}
+
 export function ForecastTab() {
   const role = useSpireStore((s) => s.role);
   const [params] = useSearchParams();
   // Honor an inbound ?unit=… deep link (e.g. from PredictedFailurePanel's
-  // Draft Action button). Defaults to FLEET if no param.
-  const initialUnit = params.get("unit") ?? "FLEET";
+  // Draft Action button). URL param wins over persisted prefs (deep links
+  // are explicit operator intent), then persisted, then FLEET default.
+  const persistedRef = useRef(readForecastPrefs());
+  const initialUnit = params.get("unit") ?? persistedRef.current.unit ?? "FLEET";
+  const initialHorizon = persistedRef.current.horizon ?? "14";
   const [unit, setUnit] = useState<string>(initialUnit);
-  const [horizon, setHorizon] = useState<Horizon>("14");
+  const [horizon, setHorizon] = useState<Horizon>(initialHorizon);
   const [data, setData] = useState<Forecast | null>(null);
   const [units, setUnits] = useState<string[]>([]);
+  // Issues #19, #20, #21, #22 — explicit error + loading state. The prior
+  // implementation swallowed errors with a no-op `.catch(() => {})` and
+  // left the skeleton on screen forever, which the operator interpreted
+  // as "the chart loads once and then nothing happens" when nav-ing away
+  // and back during a transient backend hiccup. We now track:
+  //   - loading: a request is in flight
+  //   - error:   the last request failed (with a retry CTA)
+  // Plus an AbortController + request-generation guard to discard stale
+  // responses when unit/horizon change rapidly.
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  // Bumped on every manual retry so the fetch effect re-runs even when
+  // unit/horizon haven't changed.
+  const [reloadKey, setReloadKey] = useState(0);
+  // Task #3 follow-on: timestamp of the last successful response so the
+  // operator can see how stale the displayed projection is. Wall-clock
+  // time avoids the complexity of an interval-driven "X seconds ago".
+  const [lastRefreshed, setLastRefreshed] = useState<number | null>(null);
+  // Generation token guards against late-arriving stale responses
+  // overwriting fresh ones (race when the user toggles unit/horizon
+  // faster than the network resolves).
+  const reqGenRef = useRef(0);
   const [chartRef, chartWidth] = useElementWidth<HTMLDivElement>();
   const CHART_HEIGHT = 360;
 
@@ -80,15 +131,55 @@ export function ForecastTab() {
       .catch(() => { /* tolerate; dropdown stays at FLEET */ });
   }, [role]);
 
+  // Task #3 follow-on: if a persisted unit isn't in the role-scoped unit
+  // list (e.g. the operator switched from MEF Commander to Maintenance
+  // Chief, whose persisted MWSS-271 isn't visible), fall back to FLEET so
+  // the dropdown isn't showing a value that isn't an option.
   useEffect(() => {
-    setData(null);
-    const targetUnit = unit === "FLEET" ? undefined : unit;
-    // Same pattern: catch transient errors so the chart shows its
-    // 'forecast unavailable' state rather than logging an uncaught.
-    api.pulse.forecast(targetUnit, Number(horizon))
-      .then(setData)
-      .catch(() => { /* keep prior data, chart shows skeleton/empty */ });
+    if (unit !== "FLEET" && units.length > 0 && !units.includes(unit)) {
+      setUnit("FLEET");
+    }
+  }, [units, unit]);
+
+  // Task #3 follow-on: write current selection to localStorage whenever
+  // it changes. Persist-on-change rather than persist-on-unmount so an
+  // unexpected reload still preserves the operator's choice.
+  useEffect(() => {
+    writeForecastPrefs(unit, horizon);
   }, [unit, horizon]);
+
+  useEffect(() => {
+    const targetUnit = unit === "FLEET" ? undefined : unit;
+    const myGen = ++reqGenRef.current;
+    const ctrl = new AbortController();
+    setLoading(true);
+    setError(null);
+    // Issues #19–#22 — pass the abort signal so we can cancel in-flight
+    // requests when the user changes unit/horizon mid-fetch (or
+    // unmounts), and gate state updates on the generation token so a
+    // late response from a previous selection cannot overwrite the
+    // current one.
+    api.pulse.forecast(targetUnit, Number(horizon), ctrl.signal)
+      .then((d) => {
+        if (myGen !== reqGenRef.current) return;
+        setData(d);
+        setError(null);
+        setLastRefreshed(Date.now());
+      })
+      .catch((e) => {
+        if (myGen !== reqGenRef.current) return;
+        // AbortError is expected on dependency changes; don't surface it.
+        if (e?.name === "AbortError") return;
+        setError(formatApiError(e));
+      })
+      .finally(() => {
+        if (myGen !== reqGenRef.current) return;
+        setLoading(false);
+      });
+    return () => ctrl.abort();
+  }, [unit, horizon, role, reloadKey]);
+
+  const reload = useCallback(() => setReloadKey((k) => k + 1), []);
 
   // Build the combined series. Null-guarded so hooks order stays stable.
   // Walkthrough audit: per-path data was passed via `<Line data={...}>`,
@@ -140,7 +231,12 @@ export function ForecastTab() {
 
   // Walkthrough #21 — keep controls mounted during fetch by NOT returning
   // an early loading state. Skeleton only fills the chart pane.
+  // Issues #19–#22 — distinguish data-present from in-flight: the chart
+  // re-renders cached data while a refresh is loading, so the operator
+  // never sees a blank screen on re-entry to the tab.
   const dataLoaded = !!data;
+  const showSkeleton = !dataLoaded && loading && !error;
+  const showError = !!error && !loading;
   const todayLabel = data?.history?.length
     ? data.history[data.history.length - 1].date.slice(5)
     : null;
@@ -208,6 +304,30 @@ export function ForecastTab() {
               ))}
             </select>
           </label>
+          {/* Issues #19–#22 — manual reload control. The chart is cached
+           * across nav-aways, but the operator can force a fresh fit on
+           * the latest snapshot without changing unit/horizon. */}
+          <div className="flex flex-col items-end gap-0.5">
+            <button
+              onClick={reload}
+              disabled={loading}
+              className="rounded-sm border border-[var(--color-border-active)] px-2 py-1 font-mono text-xs uppercase text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)] disabled:opacity-50 tracking-widest"
+              title="Re-fit Monte Carlo on latest data"
+              aria-label="Reload forecast"
+            >
+              {loading && dataLoaded ? "Refreshing…" : "Reload"}
+            </button>
+            {/* Task #3 follow-on: timestamp of last successful response so
+             * the operator can tell at a glance how stale the chart is. */}
+            {lastRefreshed != null && (
+              <span
+                className="font-mono text-[10px] uppercase text-[var(--color-text-muted)] tracking-widest tabular-nums"
+                title={new Date(lastRefreshed).toString()}
+              >
+                refreshed {new Date(lastRefreshed).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: false })}
+              </span>
+            )}
+          </div>
         </div>
       </div>
 
@@ -224,10 +344,52 @@ export function ForecastTab() {
         className="relative shrink-0 overflow-hidden rounded-md border border-[var(--color-border)] bg-[var(--color-surface)]"
         style={{ height: CHART_HEIGHT, minHeight: CHART_HEIGHT }}
       >
-        {!dataLoaded ? (
+        {/* Issues #19–#22 (review polish): when refreshing over already-
+         * rendered data, a tiny in-chart pill makes it obvious the chart
+         * is being re-fit, so the operator doesn't read stale-looking
+         * lines as fresh. */}
+        {loading && dataLoaded && !showError && (
+          <div
+            className="pointer-events-none absolute right-2 top-2 z-10 flex items-center gap-1.5 rounded-sm border border-[var(--color-border-active)] bg-[var(--color-surface)]/90 px-2 py-1 font-mono text-[10px] uppercase text-[var(--color-text-secondary)] tracking-widest shadow"
+            aria-live="polite"
+          >
+            <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-[var(--color-primary)]" />
+            Refreshing
+          </div>
+        )}
+        {showError ? (
+          // Issues #19–#22 — explicit error pane with retry. Replaces the
+          // prior silent skeleton-forever behavior on transient failures.
+          <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center font-mono text-xs text-[var(--color-text-muted)] tracking-wider">
+            <div className="font-semibold uppercase text-[var(--color-danger)] tracking-widest">
+              Forecast Unavailable
+            </div>
+            <div className="max-w-md text-[var(--color-text-secondary)] leading-relaxed">
+              {error}
+            </div>
+            <button
+              onClick={reload}
+              className="mt-1 rounded-sm border border-[var(--color-primary)] bg-[var(--color-primary)] px-3 py-1.5 font-mono text-xs font-semibold uppercase text-white hover:bg-[var(--color-primary-hover)] tracking-widest"
+            >
+              Retry
+            </button>
+          </div>
+        ) : showSkeleton ? (
           <div className="flex h-full items-center justify-center font-mono text-xs text-[var(--color-text-muted)] tracking-wider">
             <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-[var(--color-primary)] mr-2" />
             Running Monte Carlo forecast …
+          </div>
+        ) : !dataLoaded ? (
+          // No data, no error, not loading — should not happen normally,
+          // but provide a manual recovery path just in case.
+          <div className="flex h-full flex-col items-center justify-center gap-2 font-mono text-xs text-[var(--color-text-muted)] tracking-wider">
+            Forecast not loaded.
+            <button
+              onClick={reload}
+              className="rounded-sm border border-[var(--color-border-active)] px-2 py-1 uppercase tracking-widest hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
+            >
+              Load now
+            </button>
           </div>
         ) : !chartUsable ? (
           <div className="flex h-full items-center justify-center font-mono text-xs text-[var(--color-text-muted)] tracking-wider">


### PR DESCRIPTION
Re-land of the work prepared in #27 (which never merged after the master force-push). Re-applied cleanly against the new master, no IP-scrubbed files included.

  ## What's in this PR

  ### `ForecastTab`
  - Persist Unit + Horizon to `localStorage` (`FORECAST_PREFS_KEY`) so a reload returns the operator to the same view rather than the FLEET / 14d defaults. Watch-floor sessions stay on a single unit and re-open the tab repeatedly.
  - `Refreshed HH:MM:SS` timestamp pill below the Reload button so staleness is visible at a glance.
  - Re-validate the persisted unit against the role-scoped unit list on every role / data change; reset to FLEET if out of scope (prevents an out-of-scope value from sticking after a role swap).

  ### `CannibalizationTab`
  - AbortController + monotonic generation guard around the cannibalization fetch so a fast role swap or post-propose refetch cannot land a stale response on top of a newer one.
  - After `commit()` succeeds, trigger a fresh fetch so open-needs and matches re-pull from the server (optimistic row stays for instant feedback; server truth resolves moments later, and any newly-deadlined donor surfaces in `donor_candidates` for sibling needs).
  - Reload button + `Refreshed HH:MM:SS` timestamp in the Needs header, matching the ForecastTab affordance.
  - All three reload call sites collapsed into one `useCallback`-wrapped `reload()` handler.

  ### `api.ts`
  - `pulse.cannibalization()` now accepts an optional `AbortSignal`.

  ### Backend canary (`backend/main.py` lifespan)
  - After dataset boot, run the cannibalization endpoint internally and log per-equipment-type donor coverage. Issue #17 fixed donor matching from 0/32 to 32/32; if a future matcher / dataset change regresses that, the warning fires at startup instead of being discovered by a pilot.

    ```
    [SPIRE] Cannibalization canary: 32/32 open needs have at least one donor candidate.
    ```

  ## Verification (during prior #27 cycle)
  - Forecast: Unit/Horizon persist across reload; timestamp advances on Reload.
  - Cannib: Reload button works; per-donor Propose flow shows toast AND advances the refreshed timestamp (`POST /propose` → `GET /cannibalization`).
  - `tsc --noEmit` clean.

  ## Sister PRs in this round
  This is the first of several focused follow-on PRs. Sister PRs will cover RiskBoard / FleetOverview race-guard parity and BASTION AlertRow keyboard accessibility — same lane, kept separate so each can be reviewed in isolation.