### PR TITLE
PULSE: race-guard parity for RiskBoard and FleetOverview tabs

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -79,15 +79,18 @@ export const api = {
       }, false),
   },
   pulse: {
-    fleetOverview: () => jsonFetch<FleetOverview>("/pulse/fleet-overview"),
-    riskBoard: (top = 20) => jsonFetch<RiskBoard>(`/pulse/risk-board?top=${top}`),
-    assetDeepDive: (assetId: string) => jsonFetch<AssetDeepDive>(`/pulse/assets/${encodeURIComponent(assetId)}`),
+    // Every PULSE endpoint accepts an optional AbortSignal so callers can
+    // cancel in-flight requests when navigating away or changing inputs.
+    // Without this, late-arriving responses overwrite fresh ones (race)
+    // and the UI desyncs from server truth. (PRs #29 + #30 together.)
+    fleetOverview: (signal?: AbortSignal) =>
+      jsonFetch<FleetOverview>("/pulse/fleet-overview", { signal }),
+    riskBoard: (top = 20, signal?: AbortSignal) =>
+      jsonFetch<RiskBoard>(`/pulse/risk-board?top=${top}`, { signal }),
+    assetDeepDive: (assetId: string, signal?: AbortSignal) =>
+      jsonFetch<AssetDeepDive>(`/pulse/assets/${encodeURIComponent(assetId)}`, { signal }),
     cannibalization: (signal?: AbortSignal) =>
       jsonFetch<Cannibalization>("/pulse/cannibalization", { signal }),
-    // Issues #19–#22 — accept an AbortSignal so callers can cancel
-    // in-flight requests when navigating away or changing inputs. Without
-    // this, late-arriving responses overwrite fresh ones (race) and the
-    // chart appears stuck on stale or missing data.
     forecast: (unit?: string, window = 14, signal?: AbortSignal) =>
       jsonFetch<Forecast>(
         `/pulse/forecast?window=${window}${unit ? `&unit=${encodeURIComponent(unit)}` : ""}`,
@@ -159,7 +162,7 @@ export const api = {
       ),
   },
   bastion: {
-    cop: () => jsonFetch<BastionCOP>("/bastion/cop"),
+    cop: (signal?: AbortSignal) => jsonFetch<BastionCOP>("/bastion/cop", { signal }),
     alerts: (limit = 30) =>
       jsonFetch<BastionAlertsResponse>(`/bastion/alerts?limit=${limit}`),
     fusedThreats: () => jsonFetch<{ fused_threats: FusedThreat[] }>("/bastion/fused-threats"),

--- a/frontend/src/views/pulse/FleetOverviewTab.tsx
+++ b/frontend/src/views/pulse/FleetOverviewTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { api, type FleetOverview, type BastionCOPUnit } from "../../api";
 import { withRetry } from "../../api-retry";
@@ -20,18 +20,32 @@ export function FleetOverviewTab() {
   const [error, setError] = useState<string | null>(null);
   const [view, setView] = useState<View>("heatmap");
   const [hideEmptyColumns, setHideEmptyColumns] = useState(true);
+  // Race-guard parity: monotonic generation tokens guard against late-
+  // arriving stale responses overwriting fresh ones when role swaps
+  // faster than the network resolves. Two refs because the fleet and
+  // BASTION COP fetches run in parallel and resolve independently.
+  const overviewGenRef = useRef(0);
+  const copGenRef = useRef(0);
 
   useEffect(() => {
     setData(null);
     setError(null);
+    const myOverviewGen = ++overviewGenRef.current;
+    const myCopGen = ++copGenRef.current;
+    const ctrl = new AbortController();
     // Walkthrough audit: prior code surfaced raw 502 HTML body
     // ('<html>...502 Bad Gateway...</html>') as the error string,
     // which dumped HTML markup straight into the UI. Use withRetry so
     // transient deploy 5xx self-heal, and on terminal failure show a
     // human-readable message instead of the upstream HTML.
-    withRetry(() => api.pulse.fleetOverview())
-      .then(setData)
+    withRetry(() => api.pulse.fleetOverview(ctrl.signal))
+      .then((d) => {
+        if (myOverviewGen !== overviewGenRef.current) return;
+        setData(d);
+      })
       .catch((e) => {
+        if (myOverviewGen !== overviewGenRef.current) return;
+        if (e?.name === "AbortError") return;
         const raw = String(e);
         // If the upstream is HTML (502/504 from nginx), don't surface
         // tags; show a posture line instead.
@@ -40,7 +54,17 @@ export function FleetOverviewTab() {
           : raw.length > 140 ? raw.slice(0, 140) + "…" : raw;
         setError(friendly);
       });
-    api.bastion.cop().then((c) => setCopUnits(c.units)).catch(() => setCopUnits([]));
+    api.bastion.cop(ctrl.signal)
+      .then((c) => {
+        if (myCopGen !== copGenRef.current) return;
+        setCopUnits(c.units);
+      })
+      .catch((e) => {
+        if (myCopGen !== copGenRef.current) return;
+        if (e?.name === "AbortError") return;
+        setCopUnits([]);
+      });
+    return () => ctrl.abort();
   }, [role]);
 
   // Walkthrough #3, #51 — canonical MC rate by unit name from BASTION COP.

--- a/frontend/src/views/pulse/RiskBoardTab.tsx
+++ b/frontend/src/views/pulse/RiskBoardTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import clsx from "clsx";
 import { LineChart, Line, ResponsiveContainer } from "recharts";
@@ -40,12 +40,31 @@ export function RiskBoardTab() {
   const [detailLoading, setDetailLoading] = useState(false);
   // Walkthrough #20 — Draft Action surfaces a modal of recommend_actions.
   const [draftActionFor, setDraftActionFor] = useState<RiskBoardAsset | null>(null);
+  // Race-guard parity: monotonic generation tokens guard against late-
+  // arriving stale responses overwriting fresh ones — e.g. an operator
+  // toggling roles faster than the network resolves, or the deep-dive
+  // detail fetch outliving a switch to a different asset.
+  const boardGenRef = useRef(0);
+  const detailGenRef = useRef(0);
 
   useEffect(() => {
     setBoard(null);
     setSelected(null);
     setDetail(null);
-    api.pulse.riskBoard(30).then(setBoard).catch((e) => setError(formatApiError(e)));
+    setError(null);
+    const myGen = ++boardGenRef.current;
+    const ctrl = new AbortController();
+    api.pulse.riskBoard(30, ctrl.signal)
+      .then((b) => {
+        if (myGen !== boardGenRef.current) return;
+        setBoard(b);
+      })
+      .catch((e) => {
+        if (myGen !== boardGenRef.current) return;
+        if (e?.name === "AbortError") return;
+        setError(formatApiError(e));
+      });
+    return () => ctrl.abort();
   }, [role]);
 
   const filteredAssets = useMemo(() => {
@@ -72,11 +91,24 @@ export function RiskBoardTab() {
     if (!selected) return;
     setDetailLoading(true);
     setDetail(null);
+    const myGen = ++detailGenRef.current;
+    const ctrl = new AbortController();
     api.pulse
-      .assetDeepDive(selected)
-      .then(setDetail)
-      .catch((e) => setError(formatApiError(e)))
-      .finally(() => setDetailLoading(false));
+      .assetDeepDive(selected, ctrl.signal)
+      .then((d) => {
+        if (myGen !== detailGenRef.current) return;
+        setDetail(d);
+      })
+      .catch((e) => {
+        if (myGen !== detailGenRef.current) return;
+        if (e?.name === "AbortError") return;
+        setError(formatApiError(e));
+      })
+      .finally(() => {
+        if (myGen !== detailGenRef.current) return;
+        setDetailLoading(false);
+      });
+    return () => ctrl.abort();
   }, [selected]);
 
   if (error) return <ErrorPanel msg={error} />;


### PR DESCRIPTION
Race-guard parity follow-on to #29.

  PR #29 (re-land) closed the gap on Forecast and Cannibalization. The same race / no-cancel pattern was sitting in two more PULSE tabs; this brings them to parity.

  ## RiskBoardTab
  - Wrap the role-driven board fetch and the per-asset deep-dive fetch in `AbortController` + monotonic generation guards (`boardGenRef`, `detailGenRef`). A fast role swap (or fast asset selection while a prior detail call is mid-flight) can no longer land a stale payload on top of a fresh one.
  - `AbortError` suppressed silently — that's expected on cancel, not an error worth surfacing in the panel.

  ## FleetOverviewTab
  - Same generation-guard pattern around the parallel `fleetOverview()` + `bastion.cop()` fetches. Two refs because the two calls resolve independently; a stale COP payload can otherwise shift the canonical MC% map out from under a fresh fleet view.
  - `AbortController` shared across both — unmount or role change cancels both in flight.

  ## `api.ts`
  - `pulse.fleetOverview`, `pulse.riskBoard`, `pulse.assetDeepDive`, and `bastion.cop` now accept an optional `AbortSignal` pass-through.

  ## Verification
  - `tsc --noEmit` clean.
  - Pattern mirrors the `pulse.cannibalization` / `forecast` guards already shipped in #29.

  ## Sister PR
  BASTION AlertRow keyboard accessibility — same lane, separate PR so each can be reviewed in isolation.