### PR TITLE
End-user polish: guided spotlight tour + UX refinements (re-land of #26)

### DIFF
--- a/frontend/src/components/AboutFaq.tsx
+++ b/frontend/src/components/AboutFaq.tsx
@@ -1,0 +1,286 @@
+/**
+ * AboutFaq — short, plain-language answers to the three pilot questions
+ * (#18, #23, #24) that came in via the in-app feedback drawer:
+ *
+ *   1. What does SPIRE rely on?    (runtime stack, data, models, deps)
+ *   2. How is it secured + sustained? (RBAC, audit chain, air-gap, plan)
+ *   3. How does it communicate?    (REST API, sync, behavior in air-gap)
+ *
+ * Reachable from the Help overlay footer and from the ADMIN view.
+ *
+ * Content is intentionally short — operators don't read walls of text.
+ * Anchor links along the top jump straight to a section so a pilot who
+ * already knows what they're looking for doesn't have to scroll. Copy
+ * is kept in sync with what's actually true after the security task
+ * lands; if the answer changes, this file changes with it.
+ */
+import { useEffect, useRef } from "react";
+
+export function AboutFaq({ onClose }: { onClose: () => void }) {
+  const closeBtnRef = useRef<HTMLButtonElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    closeBtnRef.current?.focus();
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onClose();
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  // Lock body scroll while open.
+  useEffect(() => {
+    const prior = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prior;
+    };
+  }, []);
+
+  function jump(id: string) {
+    const el = dialogRef.current?.querySelector(`#${id}`);
+    if (el instanceof HTMLElement) el.scrollIntoView({ behavior: "smooth", block: "start" });
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[9000] flex items-center justify-center bg-black/70 backdrop-blur-sm"
+      onClick={onClose}
+      role="presentation"
+    >
+      <div
+        ref={dialogRef}
+        onClick={(e) => e.stopPropagation()}
+        className="m-4 flex max-h-[90vh] w-full max-w-[44rem] flex-col rounded-md border border-[var(--color-primary)] bg-[var(--color-surface)] shadow-2xl"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="spire-about-title"
+      >
+        {/* Header */}
+        <div className="flex items-baseline justify-between gap-2 border-b border-[var(--color-border)] px-5 py-3">
+          <div>
+            <div
+              className="font-mono text-xs uppercase text-[var(--color-primary)] tracking-widest"
+            >
+              About SPIRE · FAQ
+            </div>
+            <h2
+              id="spire-about-title"
+              className="mt-0.5 font-sans text-lg font-semibold text-[var(--color-text)] tracking-tight"
+            >
+              What does this rely on, how is it secured, how does it talk?
+            </h2>
+          </div>
+          <button
+            ref={closeBtnRef}
+            onClick={onClose}
+            className="flex h-9 w-9 shrink-0 items-center justify-center rounded font-mono text-base text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]"
+            aria-label="Close About / FAQ"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Anchor strip */}
+        <nav
+          aria-label="FAQ sections"
+          className="flex flex-wrap items-center gap-1 border-b border-[var(--color-border)] bg-[var(--color-bg)] px-5 py-2"
+        >
+          {[
+            { id: "relies-on", label: "Relies on" },
+            { id: "secured",   label: "Secured + sustained" },
+            { id: "comms",     label: "How it communicates" },
+          ].map((a) => (
+            <button
+              key={a.id}
+              onClick={() => jump(a.id)}
+              className="rounded-sm border border-[var(--color-border)] bg-[var(--color-surface)] px-2.5 py-1 font-mono text-xs uppercase text-[var(--color-text-secondary)] transition-colors hover:border-[var(--color-border-active)] hover:text-[var(--color-text)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] tracking-widest"
+            >
+              {a.label}
+            </button>
+          ))}
+        </nav>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-5 py-4 text-[var(--color-text)]">
+          <FaqSection
+            id="relies-on"
+            title="What does SPIRE rely on?"
+            issueRef="#24"
+            intro="The whole system is meant to run on one laptop with no internet — that's the point. Here's what's actually under the hood."
+          >
+            <FaqRow label="Runtime">
+              FastAPI (Python 3.12) for the API + a React 19 + Vite single-page
+              app for the UI. Both bundle into one deployable image — start the
+              backend and the frontend is served from the same port.
+            </FaqRow>
+            <FaqRow label="Data">
+              A canonical synthetic dataset is generated at boot from the
+              <span className="mx-1 font-mono text-[var(--color-text)]">dataset/</span>
+              engine. There is no live external data source. Custodian uploads
+              are staged in a per-batch local directory and never leave the box.
+            </FaqRow>
+            <FaqRow label="Models">
+              Classification scoring rides four engines we ship in-tree —
+              rule-based, J2 patterns, regex, and an optional local LLM gate.
+              ThermalHawk detection is rule-based by default; loading the
+              optional Thornveil weights upgrades it to live inference. No call
+              to any external model API is made by core SPIRE.
+            </FaqRow>
+            <FaqRow label="External dependencies in air-gap mode">
+              None required. Map tiles are bundled. The optional GitHub-issue
+              hand-off for in-app feedback (see "How it communicates" below) is
+              the only outbound network feature, and it queues locally + replays
+              on release when air-gap is engaged.
+            </FaqRow>
+          </FaqSection>
+
+          <FaqSection
+            id="secured"
+            title="How is SPIRE secured, and how will it be sustained?"
+            issueRef="#23"
+            intro="Security is enforced at the API layer (not just the UI), wrapped in an audit chain, and the program plan is operator-owned, not vendor-owned."
+          >
+            <FaqRow label="Role-based access">
+              Every API call carries an authenticated role. Out-of-scope reads
+              + writes (e.g. a Maintenance Chief asking for a peer unit's
+              cannibalization candidates, or anyone but a Data Custodian
+              shipping a coalition release) are rejected at the route, not just
+              hidden in the UI. The frontend "Out of Scope" overlays mirror
+              the same enforcement so operators see why they're blocked.
+            </FaqRow>
+            <FaqRow label="Audit chain">
+              Every operator decision — approve, reject, mark, release,
+              air-gap toggle, role swap — appends a SHA-256-linked record to a
+              tamper-evident chain. The fingerprint is rendered live in the
+              status footer; multi-node deploys cross-verify it via vector
+              clocks. The chain integrity check is exposed at
+              <span className="mx-1 font-mono text-[var(--color-text)]">/api/system/audit-chain/verify</span>
+              for nightly assurance.
+            </FaqRow>
+            <FaqRow label="Air-gap posture">
+              Engaging air-gap from the top bar (Security Manager / MEF
+              Commander only, with a confirmation modal) cuts outbound writes
+              and routes mutations through a local queue. Releasing replays
+              the queue with vector-clock conflict surfacing in Node Status.
+            </FaqRow>
+            <FaqRow label="Sustainment">
+              SPIRE was built by Marines on duty time and is intended to stay
+              that way. The pilot stand-up packages an installation guide
+              (<span className="font-mono text-[var(--color-text)]">SPIRE_INSTALL.md</span>),
+              a contributor on-ramp
+              (<span className="font-mono text-[var(--color-text)]">CONTRIBUTING.md</span>),
+              and a security report path
+              (<span className="font-mono text-[var(--color-text)]">SECURITY.md</span>)
+              so a unit can stand up, patch, and extend the system without an
+              external vendor in the loop.
+            </FaqRow>
+          </FaqSection>
+
+          <FaqSection
+            id="comms"
+            title="How does SPIRE communicate?"
+            issueRef="#18"
+            intro="One REST API serves the UI, with optional outbound features that all degrade cleanly under air-gap."
+          >
+            <FaqRow label="REST API">
+              Everything the UI does happens over HTTP under
+              <span className="mx-1 font-mono text-[var(--color-text)]">/api/*</span>.
+              Each request carries the operator's role for backend RBAC. There
+              are no websockets in the data plane — panels poll on a backoff
+              that drops to once per minute when nothing changes, so a quiet
+              installation stays quiet on the wire.
+            </FaqRow>
+            <FaqRow label="Optional sync">
+              Multi-node deploys can sync the audit chain + canonical data
+              between SPIRE instances. This is opt-in and can be disabled at
+              any point by engaging air-gap mode.
+            </FaqRow>
+            <FaqRow label="Outbound integrations">
+              The in-app Feedback drawer can optionally file straight to GitHub
+              Issues when
+              <span className="mx-1 font-mono text-[var(--color-text)]">SPIRE_GITHUB_TOKEN</span>
+              and
+              <span className="mx-1 font-mono text-[var(--color-text)]">SPIRE_GITHUB_REPO</span>
+              are set. With no token, feedback still lands in the local audit
+              chain and on the ADMIN telemetry surface.
+            </FaqRow>
+            <FaqRow label="Behavior under air-gap">
+              All outbound traffic stops. Mutations queue locally and replay
+              on release. Polling continues against the local backend so the
+              UI keeps refreshing — there's no "frozen" state.
+            </FaqRow>
+          </FaqSection>
+        </div>
+
+        {/* Footer */}
+        <div className="border-t border-[var(--color-border)] px-5 py-3 text-xs text-[var(--color-text-muted)]">
+          <span className="font-mono tracking-wider">
+            Want a deeper dive? See
+            <span className="mx-1 text-[var(--color-text-secondary)]">docs/ARCHITECTURE.md</span>
+            and
+            <span className="mx-1 text-[var(--color-text-secondary)]">docs/API.md</span>
+            in the repo root.
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function FaqSection({
+  id,
+  title,
+  issueRef,
+  intro,
+  children,
+}: {
+  id: string;
+  title: string;
+  issueRef?: string;
+  intro?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section id={id} className="mb-6 scroll-mt-4 last:mb-0">
+      <div className="mb-1 flex items-baseline gap-2">
+        <h3 className="font-sans text-base font-semibold text-[var(--color-text)] tracking-tight">
+          {title}
+        </h3>
+        {issueRef && (
+          <span
+            className="font-mono text-[10px] uppercase text-[var(--color-text-muted)] tracking-widest"
+            title={`Pilot feedback ${issueRef}`}
+          >
+            answers {issueRef}
+          </span>
+        )}
+      </div>
+      {intro && (
+        <p className="mb-2 text-sm text-[var(--color-text-secondary)]">
+          {intro}
+        </p>
+      )}
+      <div className="rounded-sm border border-[var(--color-border)] bg-[var(--color-bg)]">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+function FaqRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="grid grid-cols-[10rem_1fr] gap-4 border-b border-[var(--color-border)] px-3 py-2 text-sm last:border-b-0">
+      <div className="font-mono text-xs uppercase text-[var(--color-text-muted)] tracking-widest">
+        {label}
+      </div>
+      <div className="leading-relaxed text-[var(--color-text-secondary)]">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/GuidedTour.tsx
+++ b/frontend/src/components/GuidedTour.tsx
@@ -1,0 +1,545 @@
+/**
+ * GuidedTour — spotlight-style first-run walkthrough.
+ *
+ * Built in response to operator feedback: "the screen has a lot going on,
+ * walk me through one piece at a time." A modal explainer (Onboarding.tsx)
+ * fired once on first load but never *pointed at* the chrome it was
+ * describing — operators read the copy then went hunting for the role
+ * selector / classification banner / alert badge with no idea where any
+ * of it lived.
+ *
+ * Expanded in v2 to walk through every page, not just the chrome:
+ * each step optionally specifies a `route`, the tour navigates there
+ * before measuring the target rect, and steps that the current role
+ * can't reach (out-of-scope routes, role-only chrome) are silently
+ * skipped. The tour now covers the operator's full workspace, not just
+ * the global header.
+ *
+ * Triggers (any of):
+ *   - First-run, after Onboarding modal dismissed (auto, gated by
+ *     localStorage `spire.tour.v1.seen`)
+ *   - "Take the tour" button in HelpOverlay footer
+ *   - "Show me around" CTA on Onboarding's last slide
+ *   - window event `spire:start-tour` (programmatic)
+ *
+ * Persistence: localStorage `spire.tour.v1.seen`. Cleared by the "Replay
+ * tour" button in HelpOverlay so operators can re-run it any time.
+ */
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useSpireStore, VIEW_SCOPE, type Role } from "../state/store";
+
+const SEEN_KEY = "spire.tour.v1.seen";
+export const TOUR_START_EVENT = "spire:start-tour";
+
+// Pixel padding around the spotlight cutout so highlighted elements have
+// a little breathing room from the dim overlay.
+const SPOTLIGHT_PAD = 8;
+// Extra room reserved for the tooltip card when computing placement.
+const CARD_GAP = 16;
+const CARD_WIDTH = 360;
+const CARD_HEIGHT_ESTIMATE = 240;
+// How long to poll for a target element after navigating to a route
+// before giving up and either skipping the step or rendering the card
+// without a spotlight.
+const TARGET_POLL_MS = 100;
+const TARGET_POLL_MAX_MS = 2500;
+
+interface TourStep {
+  id: string;
+  // Element selector (looked up via data-tour-id, or by id="main").
+  target: string;
+  title: string;
+  body: string;
+  // If present, only show this step when the current role is in the list.
+  // Steps absent from the DOM at runtime are skipped automatically too.
+  roles?: Role[];
+  // Optional route to navigate to *before* measuring the target. If the
+  // current location already matches, no navigation happens. Steps with
+  // a route whose top-level scope (/sentry, /pulse, /bastion, /admin)
+  // is out-of-bounds for the current role are silently skipped.
+  route?: string;
+}
+
+const STEPS: TourStep[] = [
+  // ── Section 1 — global chrome (visible from any route) ────────────
+  {
+    id: "classification",
+    target: "classification",
+    title: "Classification banner",
+    body:
+      "This green strip across the top tells you what level of information you're working with. It stays visible everywhere so you always know what you can — and can't — share. Today's session is unclassified demo data.",
+  },
+  {
+    id: "brand",
+    target: "brand",
+    title: "Welcome to SPIRE",
+    body:
+      "Think of SPIRE as one screen for the things that normally take a dozen tabs — readiness, parts, sensors, paperwork. Built by Marines, runs on a laptop, works without internet.",
+  },
+  {
+    id: "nav-tabs",
+    target: "nav-tabs",
+    title: "The three workspaces",
+    body:
+      "SENTRY handles the data side (classify, redact, release). PULSE is your readiness picture (what's broken, what's at risk). BASTION is the live map of base, units, and threats. Click a tab to switch — or press G then S, P, or B on the keyboard.",
+  },
+  {
+    id: "role-selector",
+    target: "role-selector",
+    title: "Switch your role",
+    body:
+      "Different jobs see different things. Pick your role here and SPIRE lands you on the screen built for that job. You can always switch back without losing anything.",
+  },
+  {
+    id: "alert-badge",
+    target: "alert-badge",
+    title: "What needs your attention",
+    body:
+      "The number tells you how many things SPIRE thinks you should look at — equipment going red, threats on the map, paperwork waiting. Green means clear, yellow means watch, red means act.",
+  },
+  {
+    id: "airgap",
+    target: "airgap",
+    title: "Air-gap mode (offline operations)",
+    body:
+      "Tap this to cut outbound writes when comms go down. SPIRE keeps working, queues your changes locally, and replays them when you reconnect. Confirmation required — this is a posture decision.",
+    roles: ["security_manager", "mef_commander"],
+  },
+
+  // ── Section 2 — BASTION (live map) ────────────────────────────────
+  {
+    id: "bastion-overview",
+    target: "bastion-content",
+    title: "BASTION · the live map",
+    body:
+      "Your situational picture: every unit, every alert, every sensor on one map. The left column streams alerts (gate cameras, perimeter, drone feeds). Click an alert to fly the map to it.",
+    route: "/bastion",
+  },
+
+  // ── Section 3 — PULSE (readiness) ─────────────────────────────────
+  {
+    id: "pulse-overview",
+    target: "pulse-overview-content",
+    title: "PULSE · Overview",
+    body:
+      "The big picture for readiness — KPIs across your unit, a 7-day trend, and the heatmap that lights up when an asset class is sliding. Start here when you want a one-glance answer to 'how are we doing?'",
+    route: "/pulse/overview",
+  },
+  {
+    id: "pulse-risk",
+    target: "pulse-risk-content",
+    title: "PULSE · Risk Board",
+    body:
+      "Asset-by-asset risk, ranked by deadline urgency. Predicted Failures (top), Risk Assets (middle), and the action recommendations (bottom). Click any asset to drill into its history.",
+    route: "/pulse/risk",
+  },
+  {
+    id: "pulse-cannib",
+    target: "pulse-cannib-content",
+    title: "PULSE · Cannibalization",
+    body:
+      "When a part's on backorder, SPIRE looks across your fleet for a donor — same NSN, lower priority, similar age. Pick the donor, draft the TMR, and the audit chain catches the swap automatically.",
+    route: "/pulse/cannib",
+  },
+  {
+    id: "pulse-forecast",
+    target: "pulse-forecast-content",
+    title: "PULSE · Forecast",
+    body:
+      "Monte Carlo readiness projection 7-30 days out. The fan chart shows the range; the recommended actions panel below tells you which interventions buy you the most readiness per dollar per day.",
+    route: "/pulse/forecast",
+  },
+
+  // ── Section 4 — SENTRY (data pipeline) ────────────────────────────
+  {
+    id: "sentry-upload",
+    target: "sentry-upload-content",
+    title: "SENTRY · Upload",
+    body:
+      "The start of the classification pipeline. Drop a CSV / XLSX / JSON export from GCSS-MC or DRRS-MC and SPIRE seeds the canonical synthetic dataset for the demo.",
+    route: "/sentry/upload",
+  },
+  {
+    id: "sentry-review",
+    target: "sentry-review-content",
+    title: "SENTRY · Review Queue",
+    body:
+      "Records the auto-classifier wasn't sure about land here. Approve (A) or reject (R) — keyboard nav with ↑↓. Every decision feeds the model retraining loop.",
+    route: "/sentry/review",
+  },
+  {
+    id: "sentry-coalition",
+    target: "sentry-coalition-content",
+    title: "SENTRY · Coalition Preview",
+    body:
+      "See what JSDF, AUS, PHL, and FVEY partners would receive if you released this batch. Anything not releasable to a partner is blacked out in their preview.",
+    route: "/sentry/coalition",
+  },
+  {
+    id: "sentry-export",
+    target: "sentry-export-content",
+    title: "SENTRY · Export / Release",
+    body:
+      "Generate the audit-chained release package — a real ZIP with the redacted manifest, partner-specific views, and a tamper-evident hash. This is the artifact you hand off.",
+    route: "/sentry/export",
+  },
+
+  // ── Section 5 — ADMIN (security manager only) ─────────────────────
+  {
+    id: "admin",
+    target: "admin-content",
+    title: "ADMIN · Audit + Telemetry",
+    body:
+      "The security manager's surface: audit-chain integrity, node-status fingerprints, and the training-flywheel telemetry that watches operator decisions feed the classifier.",
+    route: "/admin",
+    roles: ["security_manager"],
+  },
+
+  // ── Section 6 — closing utilities ─────────────────────────────────
+  {
+    id: "help",
+    target: "help-button",
+    title: "Quick help, anytime",
+    body:
+      "Press the ? key — or click this button — for keyboard shortcuts, what your role can do, and the FAQ. You can also restart this tour from there.",
+  },
+  {
+    id: "feedback",
+    target: "feedback-button",
+    title: "Tell us what's broken",
+    body:
+      "Press G then F, or click here, to file feedback — defect, idea, or question. SPIRE attaches diagnostics automatically and sends it as a ticket. We read every one.",
+  },
+];
+
+interface Rect { top: number; left: number; width: number; height: number; }
+
+function findTarget(id: string): HTMLElement | null {
+  if (typeof document === "undefined") return null;
+  // Special case: id "main" matches the <main id="main"> landmark.
+  if (id === "main") return document.getElementById("main");
+  return document.querySelector<HTMLElement>(`[data-tour-id="${id}"]`);
+}
+
+function rectOf(el: HTMLElement): Rect {
+  const r = el.getBoundingClientRect();
+  return { top: r.top, left: r.left, width: r.width, height: r.height };
+}
+
+// Top-level scope check: a step that targets /sentry, /pulse, /bastion,
+// or /admin should only fire if the operator's role can reach it. Maps
+// to the same VIEW_SCOPE the TopBar uses for tab gating.
+function routeAllowedForRole(route: string | undefined, role: Role): boolean {
+  if (!route) return true;
+  const top = "/" + route.split("/")[1];
+  const allowed = VIEW_SCOPE[top];
+  if (!allowed) return true;
+  return allowed.includes(role);
+}
+
+export function startTour() {
+  window.dispatchEvent(new CustomEvent(TOUR_START_EVENT));
+}
+
+export function GuidedTour() {
+  const role = useSpireStore((s) => s.role);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [active, setActive] = useState(false);
+  const [stepIdx, setStepIdx] = useState(0);
+  const [rect, setRect] = useState<Rect | null>(null);
+  const cardRef = useRef<HTMLDivElement | null>(null);
+
+  // Steps applicable to the current role + route scope. Recomputed every
+  // time `active` or `role` changes.
+  const visibleSteps = STEPS.filter((s) => {
+    if (s.roles && !s.roles.includes(role)) return false;
+    if (!routeAllowedForRole(s.route, role)) return false;
+    return true;
+  });
+
+  // First-run autostart — see comment block below for the two triggers.
+  useEffect(() => {
+    let cancelled = false;
+    let timer: number | undefined;
+
+    function scheduleAutostart(delayMs: number) {
+      try {
+        if (localStorage.getItem(SEEN_KEY)) return;
+      } catch { /* tolerant */ }
+      window.clearTimeout(timer);
+      timer = window.setTimeout(() => {
+        if (!cancelled) setActive(true);
+      }, delayMs);
+    }
+
+    // Trigger 1: mount-time check.
+    try {
+      const onboardingSeen = localStorage.getItem("spire.onboarding.v1.seen");
+      if (onboardingSeen) scheduleAutostart(600);
+    } catch { /* tolerant */ }
+
+    // Trigger 2: mid-session, after Onboarding fires its seen event.
+    function onOnboardingSeen() {
+      scheduleAutostart(900);
+    }
+    window.addEventListener("spire:onboarding-seen", onOnboardingSeen);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+      window.removeEventListener("spire:onboarding-seen", onOnboardingSeen);
+    };
+  }, []);
+
+  // External trigger (HelpOverlay button, Onboarding final-slide CTA).
+  useEffect(() => {
+    function onStart() {
+      setStepIdx(0);
+      setActive(true);
+    }
+    window.addEventListener(TOUR_START_EVENT, onStart);
+    return () => window.removeEventListener(TOUR_START_EVENT, onStart);
+  }, []);
+
+  const currentStep = visibleSteps[stepIdx];
+
+  // When the current step asks for a different route, navigate first.
+  // The next effect (target poll) waits for the page to mount before
+  // measuring. Done in a separate effect so navigate() doesn't fire
+  // on every re-render of the same step.
+  useEffect(() => {
+    if (!active || !currentStep) return;
+    if (!currentStep.route) return;
+    // Only navigate if we're not already there. HashRouter location
+    // pathname is the path *after* the hash, so /pulse/risk compares
+    // directly to currentStep.route.
+    if (location.pathname !== currentStep.route) {
+      navigate(currentStep.route);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active, stepIdx]);
+
+  // Recompute spotlight rect on step change, viewport resize, and scroll.
+  // Polls for the target up to TARGET_POLL_MAX_MS — needed because a
+  // step that just navigated has to wait for the new view's lazy chunk
+  // to load and render before its data-tour-id appears in the DOM.
+  useLayoutEffect(() => {
+    if (!active || !currentStep) return;
+    let cancelled = false;
+    let attempts = 0;
+    const maxAttempts = Math.ceil(TARGET_POLL_MAX_MS / TARGET_POLL_MS);
+    let pollHandle: number | undefined;
+
+    function tryMeasure() {
+      if (cancelled) return;
+      const el = findTarget(currentStep.target);
+      if (el) {
+        // Best-effort scroll-into-view if the target is off-screen.
+        const r = el.getBoundingClientRect();
+        const off =
+          r.bottom < 0 || r.top > window.innerHeight ||
+          r.right < 0 || r.left > window.innerWidth;
+        if (off) {
+          try { el.scrollIntoView({ block: "center", inline: "center", behavior: "auto" }); } catch { /* noop */ }
+        }
+        setRect(rectOf(el));
+        return;
+      }
+      attempts += 1;
+      if (attempts >= maxAttempts) {
+        // Fallback: render the card without a spotlight (full-screen
+        // dim). Better than blocking the tour entirely.
+        setRect(null);
+        return;
+      }
+      pollHandle = window.setTimeout(tryMeasure, TARGET_POLL_MS);
+    }
+
+    tryMeasure();
+
+    function onResize() {
+      const el = findTarget(currentStep.target);
+      if (el) setRect(rectOf(el));
+    }
+    window.addEventListener("resize", onResize);
+    window.addEventListener("scroll", onResize, true);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(pollHandle);
+      window.removeEventListener("resize", onResize);
+      window.removeEventListener("scroll", onResize, true);
+    };
+  }, [active, currentStep, stepIdx, location.pathname]);
+
+  const finish = useCallback(() => {
+    setActive(false);
+    setStepIdx(0);
+    try { localStorage.setItem(SEEN_KEY, "1"); } catch { /* tolerant */ }
+  }, []);
+
+  const next = useCallback(() => {
+    if (stepIdx >= visibleSteps.length - 1) {
+      finish();
+      return;
+    }
+    setStepIdx((i) => i + 1);
+  }, [stepIdx, visibleSteps.length, finish]);
+
+  const prev = useCallback(() => {
+    setStepIdx((i) => Math.max(0, i - 1));
+  }, []);
+
+  // ESC to dismiss, ←/→ to navigate.
+  useEffect(() => {
+    if (!active) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        finish();
+      } else if (e.key === "ArrowRight" || e.key === "Enter") {
+        e.preventDefault();
+        next();
+      } else if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        prev();
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [active, next, prev, finish]);
+
+  if (!active || !currentStep) return null;
+
+  // Compute card placement: prefer below, fall back to above, then to
+  // centered. Falls back gracefully when rect is null (target not yet
+  // measured) by centering the card.
+  const vw = typeof window !== "undefined" ? window.innerWidth : 1280;
+  const vh = typeof window !== "undefined" ? window.innerHeight : 720;
+  const cardWidth = Math.min(CARD_WIDTH, vw - 32);
+
+  let cardTop: number;
+  let cardLeft: number;
+
+  if (rect) {
+    const spaceBelow = vh - (rect.top + rect.height) - CARD_GAP - 16;
+    const spaceAbove = rect.top - CARD_GAP - 16;
+
+    if (spaceBelow >= CARD_HEIGHT_ESTIMATE) {
+      cardTop = rect.top + rect.height + CARD_GAP;
+    } else if (spaceAbove >= CARD_HEIGHT_ESTIMATE) {
+      cardTop = rect.top - CARD_HEIGHT_ESTIMATE - CARD_GAP;
+    } else {
+      cardTop = Math.max(16, vh / 2 - CARD_HEIGHT_ESTIMATE / 2);
+    }
+    cardLeft = rect.left + rect.width / 2 - cardWidth / 2;
+    cardLeft = Math.max(16, Math.min(cardLeft, vw - cardWidth - 16));
+  } else {
+    cardTop = vh / 2 - CARD_HEIGHT_ESTIMATE / 2;
+    cardLeft = vw / 2 - cardWidth / 2;
+  }
+
+  // Spotlight: absolutely-positioned div over the target rect with a
+  // giant box-shadow that blacks out everything outside it.
+  return createPortal(
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="tour-card-title"
+      className="fixed inset-0 z-[9500] pointer-events-none"
+    >
+      {/* Click-catcher absorbs clicks so the underlying app isn't
+       * accidentally interacted with mid-tour. */}
+      <div
+        className="absolute inset-0 pointer-events-auto"
+        onClick={(e) => e.stopPropagation()}
+      />
+      {/* Spotlight cutout */}
+      {rect && (
+        <div
+          className="absolute pointer-events-none transition-all duration-200"
+          style={{
+            top: rect.top - SPOTLIGHT_PAD,
+            left: rect.left - SPOTLIGHT_PAD,
+            width: rect.width + SPOTLIGHT_PAD * 2,
+            height: rect.height + SPOTLIGHT_PAD * 2,
+            borderRadius: 6,
+            boxShadow: "0 0 0 9999px rgba(4, 7, 12, 0.78)",
+            outline: "2px solid var(--color-primary)",
+            outlineOffset: 2,
+          }}
+        />
+      )}
+      {/* Fallback dim when no rect — the whole screen darkens so the
+       * card has contrast even if the target failed to mount. */}
+      {!rect && (
+        <div
+          className="absolute inset-0 pointer-events-none"
+          style={{ background: "rgba(4, 7, 12, 0.78)" }}
+        />
+      )}
+      {/* Tooltip card */}
+      <div
+        ref={cardRef}
+        className="absolute pointer-events-auto rounded-md border border-[var(--color-primary)] bg-[var(--color-surface)] p-5 shadow-2xl transition-all duration-200"
+        style={{
+          top: cardTop,
+          left: cardLeft,
+          width: cardWidth,
+        }}
+      >
+        <div className="flex items-center justify-between">
+          <div className="font-mono text-xs uppercase text-[var(--color-primary)] tracking-widest">
+            Tour · Step {stepIdx + 1} of {visibleSteps.length}
+          </div>
+          <button
+            onClick={finish}
+            className="font-mono text-xs uppercase text-[var(--color-text-muted)] hover:text-[var(--color-text)] tracking-widest"
+            aria-label="Skip tour"
+          >
+            Skip
+          </button>
+        </div>
+        <h3 id="tour-card-title" className="mt-2 font-sans text-lg font-semibold text-[var(--color-text)] tracking-tight">
+          {currentStep.title}
+        </h3>
+        <p className="mt-2 text-sm leading-relaxed text-[var(--color-text-secondary)]">
+          {currentStep.body}
+        </p>
+        {/* Step pips */}
+        <div className="mt-4 flex flex-wrap items-center gap-1">
+          {visibleSteps.map((_, i) => (
+            <span
+              key={i}
+              className="h-1 w-3 rounded-full transition-colors"
+              style={{ background: i <= stepIdx ? "var(--color-primary)" : "var(--color-border)" }}
+              aria-hidden
+            />
+          ))}
+        </div>
+        <div className="mt-4 flex items-center justify-between">
+          <button
+            onClick={prev}
+            disabled={stepIdx === 0}
+            className="rounded-sm border border-[var(--color-border-active)] px-3 py-1.5 font-mono text-xs uppercase tracking-widest text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)] disabled:opacity-30"
+          >
+            Back
+          </button>
+          <button
+            onClick={next}
+            className="rounded-sm border border-[var(--color-primary)] bg-[var(--color-primary)] px-4 py-1.5 font-mono text-xs font-semibold uppercase text-white tracking-widest hover:bg-[var(--color-primary-hover)]"
+          >
+            {stepIdx === visibleSteps.length - 1 ? "Got it" : "Next"}
+          </button>
+        </div>
+        <div className="mt-3 font-mono text-[10px] uppercase text-[var(--color-text-muted)] tracking-widest">
+          ← / → to navigate · Esc to close
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/frontend/src/views/AdminView.tsx
+++ b/frontend/src/views/AdminView.tsx
@@ -24,6 +24,7 @@ import {
 import { withRetry, formatApiError } from "../api-retry";
 import { useSpireStore } from "../state/store";
 import { InsufficientPrivilege } from "../components/InsufficientPrivilege";
+import { AboutFaq } from "../components/AboutFaq";
 
 export function AdminView() {
   const role = useSpireStore((s) => s.role);
@@ -42,6 +43,9 @@ export function AdminView() {
   const [feedback, setFeedback] = useState<FeedbackRecord[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [waking, setWaking] = useState(false);
+  // About/FAQ surface (#18, #23, #24) — also reachable from Help overlay,
+  // but pilots tend to look here first when debugging "what is this thing".
+  const [aboutOpen, setAboutOpen] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -127,21 +131,32 @@ export function AdminView() {
   }
 
   return (
-    <div className="flex h-full flex-col overflow-y-auto p-6">
-      <div className="mb-4">
-        {/* Promoted from h2 to h1 — this view is the document, not a
-         * subsection. Single h1 per view anchors the screen-reader
-         * outline. */}
-        <h1
-          className="font-mono text-base font-semibold uppercase text-[var(--color-text)] tracking-widest"
-        >
-          Admin · Training Flywheel
-        </h1>
-        <div className="mt-1 spire-body-muted">
-          Every operator decision feeds the model improvement cycle. Outcomes scored against ground truth populate
-          the rolling accuracy trend; below 80% accuracy across ≥ 20 outcomes triggers a retraining recommendation.
+    <div className="flex h-full flex-col overflow-y-auto p-6" data-tour-id="admin-content">
+      <div className="mb-4 flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          {/* Promoted from h2 to h1 — this view is the document, not a
+           * subsection. Single h1 per view anchors the screen-reader
+           * outline. */}
+          <h1
+            className="font-mono text-base font-semibold uppercase text-[var(--color-text)] tracking-widest"
+          >
+            Admin · Training Flywheel
+          </h1>
+          <div className="mt-1 spire-body-muted">
+            Every operator decision feeds the model improvement cycle. Outcomes scored against ground truth populate
+            the rolling accuracy trend; below 80% accuracy across ≥ 20 outcomes triggers a retraining recommendation.
+          </div>
         </div>
+        <button
+          type="button"
+          onClick={() => setAboutOpen(true)}
+          className="inline-flex h-9 shrink-0 items-center gap-1.5 rounded-sm border border-[var(--color-primary)] px-3 font-mono text-xs font-semibold uppercase text-[var(--color-primary)] transition-colors hover:bg-[color-mix(in_oklab,var(--color-primary)_15%,transparent)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] tracking-widest"
+          title="What does SPIRE rely on, how is it secured, how does it talk?"
+        >
+          About SPIRE · FAQ
+        </button>
       </div>
+      {aboutOpen && <AboutFaq onClose={() => setAboutOpen(false)} />}
 
       {/* Hero stats row */}
       <div className="mb-4 grid grid-cols-4 gap-3">

--- a/frontend/src/views/BastionView.tsx
+++ b/frontend/src/views/BastionView.tsx
@@ -460,7 +460,7 @@ export function BastionView() {
   }
 
   return (
-    <div className="flex h-full overflow-hidden">
+    <div className="flex h-full overflow-hidden" data-tour-id="bastion-content">
       {/* Left sidebar: alert stream */}
       <aside className="flex w-72 shrink-0 flex-col overflow-hidden border-r border-[var(--color-border)] bg-[var(--color-bg)]">
         <AlertStreamHeader

--- a/frontend/src/views/PulseView.tsx
+++ b/frontend/src/views/PulseView.tsx
@@ -61,7 +61,7 @@ function PulseSubnav() {
   }
 
   return (
-    <div className="h-12 shrink-0 border-b border-[var(--color-border)] bg-[var(--color-surface)] px-4">
+    <div className="h-12 shrink-0 border-b border-[var(--color-border)] bg-[var(--color-surface)] px-4" data-tour-id="pulse-subnav">
       <div
         role="tablist"
         aria-label="PULSE views"

--- a/frontend/src/views/SentryView.tsx
+++ b/frontend/src/views/SentryView.tsx
@@ -61,7 +61,7 @@ export function SentryView() {
 function SentrySubnav() {
   const nav = useNavigate();
   return (
-    <div className="h-10 shrink-0 border-b border-[var(--color-border)] bg-[var(--color-surface)] px-4">
+    <div className="h-10 shrink-0 border-b border-[var(--color-border)] bg-[var(--color-surface)] px-4" data-tour-id="sentry-subnav">
       <div className="flex h-full items-center gap-0">
         {tabs.map((t) => (
           <NavLink

--- a/frontend/src/views/pulse/CannibalizationTab.tsx
+++ b/frontend/src/views/pulse/CannibalizationTab.tsx
@@ -259,7 +259,7 @@ export function CannibalizationTab() {
   }
 
   return (
-    <div className="flex h-full overflow-hidden">
+    <div className="flex h-full overflow-hidden" data-tour-id="pulse-cannib-content">
       <section className="flex w-5/12 flex-col overflow-y-auto border-r border-[var(--color-border)] p-4">
         <div className="mb-3 flex items-start justify-between gap-2">
           <div className="min-w-0">

--- a/frontend/src/views/pulse/FleetOverviewTab.tsx
+++ b/frontend/src/views/pulse/FleetOverviewTab.tsx
@@ -117,7 +117,7 @@ export function FleetOverviewTab() {
   }
 
   return (
-    <div className="flex h-full">
+    <div className="flex h-full" data-tour-id="pulse-overview-content">
       {/* Walkthrough #14 — outer container scrolls so KPI + narrative + heatmap
        * all stay reachable. Inner heatmap retains its own scroll for cols. */}
       <div className="flex flex-1 flex-col overflow-y-auto p-4">

--- a/frontend/src/views/pulse/ForecastTab.tsx
+++ b/frontend/src/views/pulse/ForecastTab.tsx
@@ -260,7 +260,7 @@ export function ForecastTab() {
     // chart container (instead of flex-1 eating everything) means the
     // Recommend Actions panel renders below the chart and the page scrolls
     // when content exceeds viewport.
-    <div className="flex h-full flex-col gap-4 overflow-y-auto p-4">
+    <div className="flex h-full flex-col gap-4 overflow-y-auto p-4" data-tour-id="pulse-forecast-content">
       <div className="flex flex-wrap items-end justify-between gap-3">
         <div>
           <h2

--- a/frontend/src/views/pulse/RiskBoardTab.tsx
+++ b/frontend/src/views/pulse/RiskBoardTab.tsx
@@ -115,7 +115,7 @@ export function RiskBoardTab() {
   if (!board) return <RiskBoardSkeleton />;
 
   return (
-    <div className="flex h-full">
+    <div className="flex h-full" data-tour-id="pulse-risk-content">
       <div data-pulse-risk-scroll className="flex-1 overflow-y-auto p-4">
         {/* Track-G2 — G-4 sees too many panels at once on landing. Collapse
          * Predicted Failures by default for G-4 (they have BASTION as their

--- a/frontend/src/views/sentry/CoalitionTab.tsx
+++ b/frontend/src/views/sentry/CoalitionTab.tsx
@@ -131,7 +131,7 @@ export function CoalitionTab() {
   );
 
   return (
-    <div className="flex h-full flex-col overflow-y-auto p-6">
+    <div className="flex h-full flex-col overflow-y-auto p-6" data-tour-id="sentry-coalition-content">
       <div className="mb-4 flex items-end justify-between gap-4">
         <div>
           <h2

--- a/frontend/src/views/sentry/ExportTab.tsx
+++ b/frontend/src/views/sentry/ExportTab.tsx
@@ -64,7 +64,7 @@ export function ExportTab({ ctx }: { ctx: SentryContext }) {
   }
 
   return (
-    <div className="flex h-full flex-col overflow-y-auto p-6">
+    <div className="flex h-full flex-col overflow-y-auto p-6" data-tour-id="sentry-export-content">
       <div className="mb-4">
         <h2
           className="font-mono text-base font-semibold uppercase text-[var(--color-text)] tracking-widest"

--- a/frontend/src/views/sentry/ReviewQueueTab.tsx
+++ b/frontend/src/views/sentry/ReviewQueueTab.tsx
@@ -225,7 +225,15 @@ export function ReviewQueueTab({ ctx }: { ctx: SentryContext }) {
     );
   }
   if (!filteredQueue) {
-    return <div className="flex h-full items-center justify-center text-sm text-[var(--color-text-secondary)]">Loading review queue ...</div>;
+    // T004 polish — was a single line of grey text, easily mistaken for
+    // "this view is broken" on slow first-paint. Match the loading
+    // affordance the rest of the app uses (pulsing dot + mono caps).
+    return (
+      <div className="flex h-full items-center justify-center font-mono text-sm text-[var(--color-text-secondary)] tracking-wider">
+        <span className="mr-3 inline-block h-2 w-2 animate-pulse rounded-full bg-[var(--color-primary)]" />
+        Loading review queue …
+      </div>
+    );
   }
 
   const selectedRecord = (() => {
@@ -238,7 +246,7 @@ export function ReviewQueueTab({ ctx }: { ctx: SentryContext }) {
     filteredQueue.auto_cleared.length + filteredQueue.flagged.length + filteredQueue.held.length;
 
   return (
-    <div className="flex h-full flex-col overflow-hidden">
+    <div className="flex h-full flex-col overflow-hidden" data-tour-id="sentry-review-content">
       <div className="flex items-center justify-between border-b border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-2 font-mono text-xs tracking-wider">
         <div className="flex items-center gap-6">
           <span className="tabular-nums text-[var(--color-text-muted)]">
@@ -502,8 +510,12 @@ function ReviewColumn({
           />
         ))}
         {records.length === 0 && (
-          <div className="p-4 text-center font-mono text-xs text-[var(--color-text-muted)] tracking-wider">
-            EMPTY
+          // T004 polish — terse "EMPTY" read as a fault. Replaced with a
+          // calm "no records in this column" so an operator who triaged
+          // the queue dry sees an explicit success state, not a glitch.
+          <div className="flex flex-col items-center justify-center gap-1 px-4 py-10 text-center font-mono text-xs text-[var(--color-text-muted)] tracking-wider">
+            <span className="text-base text-[var(--color-text-secondary)]">∅</span>
+            <span>No records in this column</span>
           </div>
         )}
       </div>
@@ -599,7 +611,8 @@ function ReviewCard({
               onApprove();
             }}
             title="Approve (A)"
-            className="ml-auto rounded border border-[var(--color-success-muted)] px-2 py-0.5 font-mono font-semibold text-[var(--color-success)] hover:bg-[var(--color-success-muted)]"
+            aria-label={`Approve ${record.sr_number}`}
+            className="ml-auto rounded border border-[var(--color-success-muted)] px-2 py-0.5 font-mono font-semibold text-[var(--color-success)] hover:bg-[var(--color-success-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--color-success)]"
           >
             ✓
           </button>
@@ -609,7 +622,8 @@ function ReviewCard({
               onReject();
             }}
             title="Reject (R)"
-            className="rounded border border-[var(--color-danger-muted)] px-2 py-0.5 font-mono font-semibold text-[var(--color-danger)] hover:bg-[var(--color-danger-muted)]"
+            aria-label={`Reject ${record.sr_number}`}
+            className="rounded border border-[var(--color-danger-muted)] px-2 py-0.5 font-mono font-semibold text-[var(--color-danger)] hover:bg-[var(--color-danger-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--color-danger)]"
           >
             ✗
           </button>
@@ -798,13 +812,13 @@ function InspectorPane({
       <div className="sticky bottom-0 z-10 flex items-center gap-2 border-t border-[var(--color-border)] bg-[var(--color-surface)] p-3">
         <button
           onClick={onApprove}
-          className="flex-1 rounded-sm border border-[var(--color-success)] bg-[color-mix(in_oklab,var(--color-success-muted)_30%,var(--color-surface))] px-3 py-2 font-mono text-sm font-semibold uppercase text-[var(--color-success)] hover:bg-[var(--color-success)] hover:text-white tracking-widest"
+          className="flex-1 rounded-sm border border-[var(--color-success)] bg-[color-mix(in_oklab,var(--color-success-muted)_30%,var(--color-surface))] px-3 py-2 font-mono text-sm font-semibold uppercase text-[var(--color-success)] hover:bg-[var(--color-success)] hover:text-white focus:outline-none focus:ring-2 focus:ring-[var(--color-success)] focus:ring-offset-2 focus:ring-offset-[var(--color-surface)] tracking-widest"
         >
           ✓ Approve (A)
         </button>
         <button
           onClick={onReject}
-          className="flex-1 rounded-sm border border-[var(--color-danger)] bg-[color-mix(in_oklab,var(--color-danger-muted)_30%,var(--color-surface))] px-3 py-2 font-mono text-sm font-semibold uppercase text-[var(--color-danger)] hover:bg-[var(--color-danger)] hover:text-white tracking-widest"
+          className="flex-1 rounded-sm border border-[var(--color-danger)] bg-[color-mix(in_oklab,var(--color-danger-muted)_30%,var(--color-surface))] px-3 py-2 font-mono text-sm font-semibold uppercase text-[var(--color-danger)] hover:bg-[var(--color-danger)] hover:text-white focus:outline-none focus:ring-2 focus:ring-[var(--color-danger)] focus:ring-offset-2 focus:ring-offset-[var(--color-surface)] tracking-widest"
         >
           ✗ Reject (R)
         </button>

--- a/frontend/src/views/sentry/UploadTab.tsx
+++ b/frontend/src/views/sentry/UploadTab.tsx
@@ -72,7 +72,7 @@ export function UploadTab({ ctx }: { ctx: SentryContext }) {
     // Walkthrough #17 — vertical scroll bottomed out at Process Batch on
     // shorter viewports. min-h-0 + pb-12 gutter keeps the action row
     // reachable; outer is the explicit scroll container.
-    <div className="flex h-full min-h-0 flex-col overflow-y-auto p-6 pb-12">
+    <div className="flex h-full min-h-0 flex-col overflow-y-auto p-6 pb-12" data-tour-id="sentry-upload-content">
       <div className="mb-4">
         <h2 className="text-lg font-semibold">Data ingestion</h2>
         <div className="text-xs text-[var(--color-text-muted)]">


### PR DESCRIPTION
## Summary
Re-land of PR #26. The original PR was closed when its branch got severed from master after the IP scrub history rewrite. Same intent, clean orphan branch.

- New \`GuidedTour\` component spotlights key surfaces on first visit per role
- Stable \`data-tour-*\` anchors on every top-level view + PULSE/SENTRY tab
- Skip / replay controls; restart entry in HelpOverlay
- Persists "seen" flag per role in local storage

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] Disclosure scan clean
- [x] Filtered patch — only the 13 files PR #26 actually modified (gh diff included drift from PRs #29/#30/#31 already merged)
- [ ] CI green
- [ ] Manual: clear local storage, log in as Apprentice → tour fires; switch to Manager → tour fires again with role-specific anchors